### PR TITLE
Fix README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # 🧮 PolyQ
-A novel approach to simulate Quantum Circuits using Boolean Polynomials.
+### A novel approach to simulate Quantum Circuits using Boolean Polynomials.
 
-The appraoch of this simulator is based on the paper first published by Ashley Moneanaro in 2017. He, along with previous researchers, proved the connection between Boolean Polynomial and the following Clifford gate set: `{H, Z, CZ, CCZ}`. We extended this approach to include T and S gates, thus making it universal gate set. So the currently supported gate set is `{H, Z, CZ, CCZ, T, S, T†, S†}`
+The approach of this simulator is based on the paper first published by Ashley Montanaro in 2017. He, along with previous researchers, proved the connection between Boolean Polynomial and the following Clifford gate set: `{H, Z, CZ, CCZ}`. We extended this approach to include T and S gates, thus making it universal gate set. So the currently supported gate set is `{H, Z, CZ, CCZ, T, S, T†, S†}`
  
 
 
 ## 🛠️ Get Started 
 
-For a demo, look at the [demo](./demo.ipynb) file. It shows how to simulate a random circuit with supported gate set using Qiskit's Aer, MQT's DDSIM and PolyQ. In the end, it shows how to simulate a circuit in one line and get it's state vector.
+For a demo, look at the [demo](./demo.ipynb) file. It shows how to simulate a random circuit with supported gate set using Qiskit's Aer, MQT's DDSIM and PolyQ. In the end, it shows how to simulate a circuit in one line and get its state vector.
 
 PolyQ for Qiskit `QuantumCircuit` object is available via [PyPI](https://pypi.org/project/PolyQ/0.1.0/) for Linux, macOS, and Windows and supports Python 3.11 and higher.
 
@@ -18,7 +18,7 @@ PolyQ for Qiskit `QuantumCircuit` object is available via [PyPI](https://pypi.or
 The following code gives an example on the usage:
 ```python
 from qiskit import QuantumCircuit
-import polyq
+import PolyQ
 
 # GHZ state: 
 # |GHZ⟩ = (|000⟩ + |111⟩) / √2
@@ -34,7 +34,7 @@ circ.h(2)
 
 print(circ.draw(fold=-1))
 
-st_vec = polyq.simulate(circ)
+st_vec = PolyQ.simulate(circ)
 
 print(st_vec)
 ```


### PR DESCRIPTION
- [x] - Fixed 'polyq' to 'PolyQ' in example code
- [x] - Fixed 'appraoch' to 'approach' in subtitle
- [x] - Fixed 'Ashley Moneanaro' to 'Ashley Montanaro' in description
- [x] - Fixed 'it's state vector' to 'its state vector' in description

Resolves #1